### PR TITLE
issue-51 :sparkles: バックグラウンドで切り替えタイミングをユーザーに通知する機能を実装

### DIFF
--- a/IntervalWalk/AppDelegate.swift
+++ b/IntervalWalk/AppDelegate.swift
@@ -44,7 +44,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
+            if granted {
+                print("通知が許可された")
+            } else {
+                print("通知が許可されていない")
+            }
+        }
+        
         return true
     }
 }
-

--- a/IntervalWalk/Extension/String+.swift
+++ b/IntervalWalk/Extension/String+.swift
@@ -20,4 +20,6 @@ extension String {
     static var stopButtonLabel: String { "停止" }
     static var speedyLabel: String { "早歩き" }
     static var slowlyLabel: String { "ゆっくり" }
+    static var localNotificationTitle: String { "インターバル・ウォーキング" }
+    static var localNotificationBody: String { "歩くスピードを切り替えましょう！" }
 }

--- a/IntervalWalk/Stopwatch/ViewController/StopwatchViewController.swift
+++ b/IntervalWalk/Stopwatch/ViewController/StopwatchViewController.swift
@@ -25,14 +25,14 @@ final class StopwatchViewController: UIViewController {
     
     private var presenter: StopwatchPresenterInput!
     func inject(presenter: StopwatchPresenterInput) {
-      self.presenter = presenter
+        self.presenter = presenter
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         timerLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 50, weight: .bold)
-
+        
         updateStartButton()
     }
     

--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,5 @@ target 'IntervalWalk' do
   pod 'FirebaseFirestore'
   pod 'FirebaseFirestoreSwift'
   pod 'IQKeyboardManagerSwift'
-  pod 'IQKeyboardManagerSwift'
   pod 'SwiftDate'
 end


### PR DESCRIPTION
### 概要
ローカル通知を用いて、バックグラウンドで3分間隔で切り替えタイミングをユーザーに伝える機能を実装。

### 関連するIssue
#51 