### PR TITLE
issue-53 :hammer: ストップウォッチを停止したときにローカル通知の予約を取り消しする機能を実装

### DIFF
--- a/IntervalWalk/Stopwatch/Presenter/StopwatchPresenter.swift
+++ b/IntervalWalk/Stopwatch/Presenter/StopwatchPresenter.swift
@@ -220,9 +220,11 @@ extension StopwatchPresenter: StopwatchPresenterInput {
         case let .running(runningState):
             addRecord()
             runningState.timer.invalidate()
+            resetLocalNotification()
             _state = .idle
         case .pause:
             addRecord()
+            resetLocalNotification()
             _state = .idle
         }
     }


### PR DESCRIPTION
### 概要
`StopwatchPresenter`でStateが`.runnning`, `.pause`であれば、ストップウォッチを停止したときにローカル通知の予約を取り消しする機能を実装

### 関連するIssue
#53 